### PR TITLE
fix(setup): use BufReadPre

### DIFF
--- a/lua/bigfile/init.lua
+++ b/lua/bigfile/init.lua
@@ -117,7 +117,7 @@ function M.setup(user_config)
   }
 
   vim.api.nvim_create_augroup("bigfile", {})
-  vim.api.nvim_create_autocmd("BufReadPost", {
+  vim.api.nvim_create_autocmd("BufReadPre", {
     group = "bigfile",
     callback = pre_bufread_callback,
   })


### PR DESCRIPTION
`pre_bufread_callback` should run on `BufReadPre`, deferred features run on `BufReadPost`. I tested it and all is good, treesitter didn't work before this change