### PR TITLE
feat: allow overriding the detection of big files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The plugin ships with common default options. No further setup is required.
 -- default config
 require("bigfile").setup {
   filesize = 2, -- size of the file in MiB, the plugin round file sizes to the closest MiB
-  pattern = { "*" }, -- autocmd pattern
+  pattern = { "*" }, -- autocmd pattern or function see <### Overriding the detection of big files>
   features = { -- features to disable
     "indent_blankline",
     "illuminate",
@@ -37,7 +37,6 @@ require("bigfile").setup {
     "vimopts",
     "filetype",
   },
-  override_detection = nil -- see <### Overriding the detection of big files> below
 }
 ```
 
@@ -65,17 +64,16 @@ require("bigfile").setup {
 
 ### Overriding the detection of big files
 
-You can add your own logic for detecting big files by setting the
-`override_detection` callback in the config. If the function doesn't return
-anything, just the filesize will be used, otherwise the returned boolean will
-be used (true -> file is big, disable features | false -> do nothing)
+You can add your own logic for detecting big files by setting `pattern` in the
+config to a function. If the function returns true file will be considered big,
+otherwise `filesize` will be used as a fallback
 
 example:
 
 ```lua
 require("bigfile").setup {
   -- detect long python files
-  override_detection = function(bufnr, filesize_mib)
+  pattern = function(bufnr, filesize_mib)
     -- you can't use `nvim_buf_line_count` because this runs on BufReadPre
     local file_contents = vim.fn.readfile(vim.api.nvim_buf_get_name(bufnr))
     local file_length = #file_contents

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ require("bigfile").setup {
     "vimopts",
     "filetype",
   },
+  override_detection = nil -- see <### Overriding the detection of big files> below
 }
 ```
 
@@ -59,6 +60,30 @@ local mymatchparen = {
 require("bigfile").setup {
   filesize = 1,
   features = { "treesitter", mymatchparen }
+}
+```
+
+### Overriding the detection of big files
+
+You can add your own logic for detecting big files by setting the
+`override_detection` callback in the config. If the function doesn't return
+anything, just the filesize will be used, otherwise the returned boolean will
+be used (true -> file is big, disable features | false -> do nothing)
+
+example:
+
+```lua
+require("bigfile").setup {
+  -- detect long python files
+  override_detection = function(bufnr, filesize_mib)
+    -- you can't use `nvim_buf_line_count` because this runs on BufReadPre
+    local file_contents = vim.fn.readfile(vim.api.nvim_buf_get_name(bufnr))
+    local file_length = #file_contents
+    local filetype = vim.filetype.match({ buf = bufnr })
+    if file_length > 5000 and filetype == "python" then
+      return true
+    end
+  end
 }
 ```
 

--- a/lua/bigfile/init.lua
+++ b/lua/bigfile/init.lua
@@ -6,6 +6,7 @@ local features = require "bigfile.features"
 ---@field filesize integer size in MiB
 ---@field pattern string|string[] see |autocmd-pattern|
 ---@field features string[] array of features
+---@field override_detection nil|fun(bufnr: number, filesize_mib: number): boolean|nil callback to override detection of big files
 local default_config = {
   filesize = 2,
   pattern = { "*" },
@@ -19,6 +20,7 @@ local default_config = {
     "vimopts",
     "filetype",
   },
+  override_detection = nil,
 }
 
 ---@param bufnr number
@@ -34,14 +36,24 @@ local function get_buf_size(bufnr)
   return math.floor(0.5 + (stats.size / (1024 * 1024)))
 end
 
-local function pre_bufread_callback(bufnr, rule)
+---@param bufnr number
+---@param config config
+local function pre_bufread_callback(bufnr, config)
   local status_ok, _ = pcall(vim.api.nvim_buf_get_var, bufnr, "bigfile_detected")
   if status_ok then
     return -- buffer has already been processed
   end
 
-  local filesize = get_buf_size(bufnr)
-  if not filesize or filesize < rule.filesize then
+  local filesize = get_buf_size(bufnr) or 0
+  local bigfile_detected = filesize >= config.filesize
+  if type(config.override_detection) == "function" then
+    local user_override = config.override_detection(bufnr, filesize)
+    if user_override ~= nil then
+      bigfile_detected = user_override
+    end
+  end
+
+  if not bigfile_detected then
     vim.api.nvim_buf_set_var(bufnr, "bigfile_detected", 0)
     return
   end
@@ -50,7 +62,7 @@ local function pre_bufread_callback(bufnr, rule)
 
   local matched_features = vim.tbl_map(function(feature)
     return features.get_feature(feature)
-  end, rule.features)
+  end, config.features)
 
   -- Categorize features and disable features that don't need deferring
   local matched_deferred_features = {}


### PR DESCRIPTION
fixes #11

adds override_detection to the config
```lua
override_detection nil|fun(bufnr: number, filesize_mib: number): boolean|nil callback to override detection of big files
```