### PR TITLE
feat: add custom autocmd for user defined features

### DIFF
--- a/lua/bigfile/init.lua
+++ b/lua/bigfile/init.lua
@@ -75,6 +75,7 @@ local function pre_bufread_callback(bufnr, config)
       for _, feature in ipairs(matched_deferred_features) do
         feature.disable(bufnr)
       end
+      vim.api.nvim_exec_autocmds("User", { pattern = "BigfileBufReadPost" })
     end,
     buffer = bufnr,
   })


### PR DESCRIPTION
I want to disable features other than defined in this plugin. I added custom autocmd named `BigfileBufReadPost` to use such as below.

```lua
vim.api.nvim_create_autocmd("User", {
  pattern = "BigfileBufReadPost",
  callback = function(args)
    vim.api.nvim_buf_call(args.buf, function()
      -- disable heavy plugin such as https://github.com/lewis6991/satellite.nvim
      vim.cmd.SatelliteDisable()
    end)
  end,
})
```

If you like to merge, I will add doc for this.