### PR TITLE
feat: add option to use bytes not MiB for filesize

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ The plugin ships with common default options. No further setup is required.
 ```lua
 -- default config
 require("bigfile").setup {
-  filesize = 2, -- size of the file in MiB, the plugin round file sizes to the closest MiB
+  filesize = 2, -- size of the file in filesize_unit, the plugin will round file sizes to the closest MiB (not bytes)
+  filesize_unit = "MiB", -- default, also available "bytes"
   pattern = { "*" }, -- autocmd pattern or function see <### Overriding the detection of big files>
   features = { -- features to disable
     "indent_blankline",
@@ -73,7 +74,7 @@ example:
 ```lua
 require("bigfile").setup {
   -- detect long python files
-  pattern = function(bufnr, filesize_mib)
+  pattern = function(bufnr, filesize)
     -- you can't use `nvim_buf_line_count` because this runs on BufReadPre
     local file_contents = vim.fn.readfile(vim.api.nvim_buf_get_name(bufnr))
     local file_length = #file_contents

--- a/lua/bigfile/init.lua
+++ b/lua/bigfile/init.lua
@@ -42,7 +42,7 @@ end
 ---@param target_unit filesize_unit
 local function convert_to_filesize_unit(size, target_unit)
   if target_unit == "MiB" then
-    return math.floor(0.5 + size / 1024 * 1024)
+    return math.floor(0.5 + size / (1024 * 1024))
   end
   return size
 end


### PR DESCRIPTION
Hi 👋 

Thanks for the great plugin!

I'm trying to use it to do minified file detection with a `pattern` function and I've found I need filesizes in bytes for it to be useful. Seems this would address #24 too.

What do you think?